### PR TITLE
 feat(auth): change `roles` to `role`

### DIFF
--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/adapters/JwtTokenClaimsCodec.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/adapters/JwtTokenClaimsCodec.java
@@ -138,7 +138,7 @@ public class JwtTokenClaimsCodec implements TokenClaimsCodecPort, JwtDecoder {
         if (roleClaim == null) {
             throw new AccessTokenDecodingException("missing claim 'scope'", token);
         }
-        if (roleClaim instanceof String role && !role.isEmpty()) {
+        if (roleClaim instanceof String role) {
             return RoleMapper.INSTANCE.toValueObject(role);
         }
         throw new AccessTokenDecodingException(

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/RoleDbEntity.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/RoleDbEntity.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "roles")
+@Table(name = "role")
 public class RoleDbEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/UserDbEntity.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/UserDbEntity.java
@@ -3,7 +3,6 @@ package com.nimbleways.springboilerplate.common.infra.database.entities;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPassword;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserCredential;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserPrincipal;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
@@ -15,13 +14,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.eclipse.collections.api.set.ImmutableSet;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 
 @SuppressWarnings("PMD.ExcessiveImports")
@@ -58,6 +55,10 @@ public class UserDbEntity {
     @NotNull
     private Instant createdAt;
 
+    @ManyToOne(cascade={CascadeType.ALL})
+    @NotNull
+    private RoleDbEntity role;
+
     @ManyToMany(cascade={CascadeType.ALL}, fetch=FetchType.EAGER)
     @JoinTable(
             name="user_role",
@@ -67,13 +68,13 @@ public class UserDbEntity {
     private Collection<RoleDbEntity> roles = new ArrayList<>();
 
     public static UserDbEntity from(NewUser newUser) {
-        List<RoleDbEntity> roles = newUser.roles().stream().map(RoleDbEntity::newFromRole).toList();
+        RoleDbEntity role = RoleDbEntity.newFromRole(newUser.role());
         final UserDbEntity userDbEntity = new UserDbEntity();
         userDbEntity.name(newUser.name());
         userDbEntity.email(newUser.email().value());
         userDbEntity.password(newUser.encodedPassword().value());
         userDbEntity.createdAt(newUser.creationDateTime());
-        userDbEntity.roles(roles);
+        userDbEntity.role(role);
         return userDbEntity;
     }
 
@@ -83,7 +84,7 @@ public class UserDbEntity {
                 name,
                 new Email(email),
                 createdAt,
-                getRoles()
+                getRole()
         );
     }
 
@@ -91,7 +92,7 @@ public class UserDbEntity {
         return new UserPrincipal(
                 id,
                 new Email(email),
-                getRoles()
+                getRole()
         );
     }
 
@@ -100,7 +101,7 @@ public class UserDbEntity {
     }
 
     @NotNull
-    private ImmutableSet<Role> getRoles() {
-        return Immutable.collectSet(roles, RoleDbEntity::toRole);
+    private Role getRole() {
+        return role.toRole();
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/UserDbEntity.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/UserDbEntity.java
@@ -17,8 +17,6 @@ import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.UUID;
 
 @SuppressWarnings("PMD.ExcessiveImports")
@@ -58,14 +56,6 @@ public class UserDbEntity {
     @ManyToOne(cascade={CascadeType.ALL})
     @NotNull
     private RoleDbEntity role;
-
-    @ManyToMany(cascade={CascadeType.ALL}, fetch=FetchType.EAGER)
-    @JoinTable(
-            name="user_role",
-            joinColumns = @JoinColumn( name= "user_id"),
-            inverseJoinColumns = @JoinColumn( name = "role_id"))
-    @NotNull
-    private Collection<RoleDbEntity> roles = new ArrayList<>();
 
     public static UserDbEntity from(NewUser newUser) {
         RoleDbEntity role = RoleDbEntity.newFromRole(newUser.role());

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/mappers/ValueObjectMapper.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/mappers/ValueObjectMapper.java
@@ -1,18 +1,7 @@
 package com.nimbleways.springboilerplate.common.infra.mappers;
 
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
-import org.eclipse.collections.api.set.ImmutableSet;
-
 public interface ValueObjectMapper<TValueObject, TPrimitive> {
     TPrimitive fromValueObject(TValueObject valueObject);
 
     TValueObject toValueObject(TPrimitive primitiveValue);
-
-    default ImmutableSet<TPrimitive> fromValueObjects(Iterable<TValueObject> valueObjects) {
-        return Immutable.collectSet(valueObjects, this::fromValueObject);
-    }
-
-    default ImmutableSet<TValueObject> toValueObjects(Iterable<TPrimitive> primitiveValues) {
-        return Immutable.collectSet(primitiveValues, this::toValueObject);
-    }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/authentication/domain/entities/UserPrincipal.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/authentication/domain/entities/UserPrincipal.java
@@ -3,12 +3,11 @@ package com.nimbleways.springboilerplate.features.authentication.domain.entities
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import java.util.UUID;
-import org.eclipse.collections.api.set.ImmutableSet;
 
 public record UserPrincipal(
     UUID id,
     Email email,
 
-    ImmutableSet<Role> roles
+    Role role
 ) {
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/signup/SignupRequest.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/signup/SignupRequest.java
@@ -7,8 +7,6 @@ import com.nimbleways.springboilerplate.common.infra.mappers.RoleMapper;
 import com.nimbleways.springboilerplate.features.users.domain.usecases.signup.SignupCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.api.set.ImmutableSet;
 
 public record SignupRequest (
     @NotBlank
@@ -18,10 +16,11 @@ public record SignupRequest (
     @NotBlank
     String password,
     @NotNull
-    ImmutableList<@Parsable(RoleMapper.class) String> roles
+    @Parsable(RoleMapper.class)
+    String role
 ) {
     public SignupCommand toSignupCommand() {
-        ImmutableSet<Role> rolesAsEnum = RoleMapper.INSTANCE.toValueObjects(roles());
-        return new SignupCommand(name(), new Email(email()), password(), rolesAsEnum);
+        Role roleAsEnum = RoleMapper.INSTANCE.toValueObject(role());
+        return new SignupCommand(name(), new Email(email()), password(), roleAsEnum);
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/signup/SignupResponse.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/signup/SignupResponse.java
@@ -2,21 +2,20 @@ package com.nimbleways.springboilerplate.features.users.api.endpoints.signup;
 
 import com.nimbleways.springboilerplate.common.infra.mappers.RoleMapper;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
-import org.eclipse.collections.api.set.ImmutableSet;
 
 public record SignupResponse(
     String id,
     String name,
     String email,
-    ImmutableSet<String> roles
+    String role
 ) {
     public static SignupResponse from(User user) {
-        ImmutableSet<String> userRoles = RoleMapper.INSTANCE.fromValueObjects(user.roles());
+        String userRole = RoleMapper.INSTANCE.fromValueObject(user.role());
         return new SignupResponse(
                 user.id().toString(),
                 user.name(),
                 user.email().value(),
-                userRoles
+                userRole
         );
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/entities/User.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/entities/User.java
@@ -5,13 +5,12 @@ import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 
 import java.time.Instant;
 import java.util.UUID;
-import org.eclipse.collections.api.set.ImmutableSet;
 
 public record User(
         UUID id,
         String name,
         Email email,
         Instant createdAt,
-        ImmutableSet<Role> roles
+        Role role
 ){
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/usecases/signup/SignupCommand.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/usecases/signup/SignupCommand.java
@@ -5,13 +5,12 @@ import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPasswo
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.features.users.domain.valueobjects.NewUser;
 import java.time.Instant;
-import org.eclipse.collections.api.set.ImmutableSet;
 
 public record SignupCommand(
         String name,
         Email email,
         String plainPassword,
-        ImmutableSet<Role> roles
+        Role role
 ) {
     public NewUser toNewUser(EncodedPassword encodedPassword, Instant creationDateTime) {
         return new NewUser(
@@ -19,7 +18,7 @@ public record SignupCommand(
                 email(),
                 encodedPassword,
                 creationDateTime,
-                roles()
+                role()
         );
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/usecases/signup/SignupUseCase.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/usecases/signup/SignupUseCase.java
@@ -26,7 +26,7 @@ public class SignupUseCase {
       public User handle(final SignupCommand signupCommand) {
           EncodedPassword encodedPassword = passwordEncoder.encode(signupCommand.plainPassword());
           Instant creationDateTime = timeProvider.instant();
-          // TODO: validate roles and fail if it doesn't exist in the repository
+          // TODO: validate role and fail if it doesn't exist in the repository
           final NewUser newUser = signupCommand.toNewUser(encodedPassword, creationDateTime);
           return userRepository.create(newUser);
       }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/valueobjects/NewUser.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/valueobjects/NewUser.java
@@ -5,13 +5,12 @@ import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPasswo
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 
 import java.time.Instant;
-import org.eclipse.collections.api.set.ImmutableSet;
 
 public record NewUser(
         String name,
         Email email,
         EncodedPassword encodedPassword,
         Instant creationDateTime,
-        ImmutableSet<Role> roles
+        Role role
 ){
 }

--- a/api/src/main/resources/db/changelog-master.yaml
+++ b/api/src/main/resources/db/changelog-master.yaml
@@ -21,6 +21,7 @@ databaseChangeLog:
   - include:
       file: changelog/20250210-165514-change-username-to-email.yaml
       relativeToChangelogFile: true
+
   - include:
-      file: changelog/20250212-144740-convert-roles-to-role.yaml
+      file: changelog/20250213-104218-convert-roles-to-role.yaml
       relativeToChangelogFile: true

--- a/api/src/main/resources/db/changelog-master.yaml
+++ b/api/src/main/resources/db/changelog-master.yaml
@@ -21,3 +21,6 @@ databaseChangeLog:
   - include:
       file: changelog/20250210-165514-change-username-to-email.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20250212-144740-convert-roles-to-role.yaml
+      relativeToChangelogFile: true

--- a/api/src/main/resources/db/changelog-whitelist.yml
+++ b/api/src/main/resources/db/changelog-whitelist.yml
@@ -4,6 +4,6 @@ whitelisted_files:
     explanation: "Example file to ignore"
   - file: "changelog/20250210-165514-change-username-to-email.yaml"
     explanation: "We are required to change 'username' column with 'email', the task was to remove 'username' field and use 'email' field instead, so ignore the 'dropColumn' command"
-  - file: "changelog/20250212-144740-convert-roles-to-role.yaml"
+  - file: "changelog/20250213-104218-convert-roles-to-role.yaml"
     explanation: "We are required to change 'roles' table to 'role' table, the task was to remove 'roles' table and use 'role' table instead, so ignore the 'dropTable' command"
 

--- a/api/src/main/resources/db/changelog-whitelist.yml
+++ b/api/src/main/resources/db/changelog-whitelist.yml
@@ -4,5 +4,6 @@ whitelisted_files:
     explanation: "Example file to ignore"
   - file: "changelog/20250210-165514-change-username-to-email.yaml"
     explanation: "We are required to change 'username' column with 'email', the task was to remove 'username' field and use 'email' field instead, so ignore the 'dropColumn' command"
-
+  - file: "changelog/20250212-144740-convert-roles-to-role.yaml"
+    explanation: "We are required to change 'roles' table to 'role' table, the task was to remove 'roles' table and use 'role' table instead, so ignore the 'dropTable' command"
 

--- a/api/src/main/resources/db/changelog/20250212-144740-convert-roles-to-role.yaml
+++ b/api/src/main/resources/db/changelog/20250212-144740-convert-roles-to-role.yaml
@@ -1,0 +1,73 @@
+databaseChangeLog:
+- changeSet:
+    id: 1739371689705-4
+    author: Yassine (generated)
+    changes:
+    - dropForeignKeyConstraint:
+        baseTableName: user_role
+        constraintName: FKj345gk1bovqvfame88rcx7yyx
+- changeSet:
+    id: 1739371689705-5
+    author: Yassine (generated)
+    changes:
+    - dropForeignKeyConstraint:
+        baseTableName: user_role
+        constraintName: FKt7e7djp752sqn6w22i6ocqy6q
+- changeSet:
+    id: 1739371689705-1
+    author: Yassine (generated)
+    changes:
+    - createTable:
+        columns:
+        - column:
+            autoIncrement: true
+            constraints:
+              nullable: false
+              primaryKey: true
+              primaryKeyName: rolePK
+            name: id
+            type: BIGINT
+        - column:
+            constraints:
+              nullable: false
+            name: role_name
+            type: VARCHAR(255)
+        tableName: role
+- changeSet:
+    id: 1739371689705-2
+    author: Yassine (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: role_id
+            type: BIGINT
+        tableName: users
+- changeSet:
+    id: 1739371689705-3
+    author: Yassine (generated)
+    changes:
+    - addForeignKeyConstraint:
+        baseColumnNames: role_id
+        baseTableName: users
+        constraintName: FK4qu1gr772nnf6ve5af002rwya
+        deferrable: false
+        initiallyDeferred: false
+        referencedColumnNames: id
+        referencedTableName: role
+        validate: true
+- changeSet:
+    id: 1739371689705-6
+    author: Yassine (generated)
+    changes:
+    - dropTable:
+        tableName: roles
+- changeSet:
+    id: 1739371689705-7
+    author: Yassine (generated)
+    changes:
+    - dropTable:
+        tableName: user_role
+

--- a/api/src/main/resources/db/changelog/20250213-104218-convert-roles-to-role.yaml
+++ b/api/src/main/resources/db/changelog/20250213-104218-convert-roles-to-role.yaml
@@ -1,20 +1,20 @@
 databaseChangeLog:
 - changeSet:
-    id: 1739371689705-4
+    id: 1739443391915-4
     author: Yassine (generated)
     changes:
     - dropForeignKeyConstraint:
         baseTableName: user_role
         constraintName: FKj345gk1bovqvfame88rcx7yyx
 - changeSet:
-    id: 1739371689705-5
+    id: 1739443391915-5
     author: Yassine (generated)
     changes:
     - dropForeignKeyConstraint:
         baseTableName: user_role
         constraintName: FKt7e7djp752sqn6w22i6ocqy6q
 - changeSet:
-    id: 1739371689705-1
+    id: 1739443391915-1
     author: Yassine (generated)
     changes:
     - createTable:
@@ -34,7 +34,7 @@ databaseChangeLog:
             type: VARCHAR(255)
         tableName: role
 - changeSet:
-    id: 1739371689705-2
+    id: 1739443391915-2
     author: Yassine (generated)
     changes:
     - addColumn:
@@ -46,7 +46,7 @@ databaseChangeLog:
             type: BIGINT
         tableName: users
 - changeSet:
-    id: 1739371689705-3
+    id: 1739443391915-3
     author: Yassine (generated)
     changes:
     - addForeignKeyConstraint:
@@ -59,13 +59,13 @@ databaseChangeLog:
         referencedTableName: role
         validate: true
 - changeSet:
-    id: 1739371689705-6
+    id: 1739443391915-6
     author: Yassine (generated)
     changes:
     - dropTable:
         tableName: roles
 - changeSet:
-    id: 1739371689705-7
+    id: 1739443391915-7
     author: Yassine (generated)
     changes:
     - dropTable:

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/JwtTokenCodecUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/JwtTokenCodecUnitTests.java
@@ -28,19 +28,19 @@ public class JwtTokenCodecUnitTests extends TokenClaimsCodecPortContractTests {
     }
 
     @Override
-    protected AccessToken getTokenWithoutRoles() {
+    protected AccessToken getTokenWithoutRole() {
         return new AccessToken(
             "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJjZmNkMjA4NDk1ZDUzNWVmYTZlN2RmZjlmOTg3NjRkYSIsInN1YiI6IjIzYTBiYTcyLWE3NzUtNGVmZS1iN2EwLTgyMTViMDViYzIyOSx1c2VybmFtZSIsImlzcyI6Im15YXBwIiwiaWF0IjoxNzA5MjI2OTcwLCJleHAiOjE3MDkyMjY5NzF9.kv9KtJkciWIhiexl6Ylx3gnaezOHVDY6ixIaVROVqDg");
     }
 
     @Override
-    protected AccessToken getTokenWithInvalidRolesArrayClaim() {
+    protected AccessToken getTokenWithInvalidRoleArrayClaim() {
         return new AccessToken(
             "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJjZmNkMjA4NDk1ZDUzNWVmYTZlN2RmZjlmOTg3NjRkYSIsInN1YiI6IjFmMTU3ZGMyLWMzZDEtNDFkNC04OGQwLTk3M2NjNWExNThkMCx1c2VybmFtZSIsImlzcyI6Im15YXBwIiwiaWF0IjoxNzA5MjI3MTQxLCJleHAiOjE3MDkyMjcxNDIsInNjb3BlIjpbMSwyLDNdfQ.3AY7vsJzUkzh5fNoP0_y9oUEDp6z1yEHvFnCvwLzyao");
     }
 
     @Override
-    protected AccessToken getTokenWithInvalidRolesScalarClaim() {
+    protected AccessToken getTokenWithInvalidRoleScalarClaim() {
         return new AccessToken(
             "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJjZmNkMjA4NDk1ZDUzNWVmYTZlN2RmZjlmOTg3NjRkYSIsInN1YiI6ImJkNTAzNzc4LTgxMjMtNDZiMy05MjA4LTE4ZGI0YzdhYWNmOCx1c2VybmFtZSIsImlzcyI6Im15YXBwIiwiaWF0IjoxNzA5MjI3MTk5LCJleHAiOjE3MDkyMjcyMDAsInNjb3BlIjoxMH0.duOIIRK8XcvMMwcmJC6-Nvads-aOQ8zVi_Y_rVzImvA");
     }

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/SpringJwtDecoderContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/SpringJwtDecoderContractTests.java
@@ -46,7 +46,7 @@ public abstract class SpringJwtDecoderContractTests {
 
         assertEquals(claims.expirationTime(), jwt.getExpiresAt());
         assertEquals(claims.creationTime(), jwt.getIssuedAt());
-        assertEquals(List.of("USER"), jwt.getClaim("scope"));
+        assertEquals("USER", jwt.getClaim("scope"));
         assertEquals(getExpectedSubject(claims.userPrincipal()), jwt.getSubject());
     }
 
@@ -76,7 +76,7 @@ public abstract class SpringJwtDecoderContractTests {
     @NotNull
     private TokenClaims getTokenClaims(Instant expirationTime) {
         return new TokenClaims(
-            aUserPrincipal().withRoles(Immutable.set.of(Role.USER)).build(),
+            aUserPrincipal().withRole(Role.USER).build(),
             adjustPrecision(expirationTime.minusSeconds(1)),
             adjustPrecision(expirationTime)
         );

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/SpringJwtDecoderContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/SpringJwtDecoderContractTests.java
@@ -8,7 +8,6 @@ import com.nimbleways.springboilerplate.common.domain.ports.TimeProviderPort;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakeTokenClaimsCodec;
 import com.nimbleways.springboilerplate.common.infra.properties.JwtProperties;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.TokenClaims;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserPrincipal;
 import com.nimbleways.springboilerplate.testhelpers.annotations.IntegrationTest;

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeTokenClaimsCodec.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeTokenClaimsCodec.java
@@ -50,7 +50,7 @@ public class FakeTokenClaimsCodec implements TokenClaimsCodecPort, JwtDecoder {
         } catch (MismatchedInputException | JsonParseException exception) {
             throw new AccessTokenDecodingException(exception, token);
         }
-        if (claimWrapper.tokenClaims.userPrincipal().roles() == null) {
+        if (claimWrapper.tokenClaims.userPrincipal().role() == null) {
             throw new AccessTokenDecodingException("missing claim 'scope'", token);
         }
         return claimWrapper.tokenClaims();
@@ -89,15 +89,14 @@ public class FakeTokenClaimsCodec implements TokenClaimsCodecPort, JwtDecoder {
             throw new JwtValidationException("", List.of(new OAuth2Error("invalid_token")));
         }
 
-        List<String> roles = tokenClaims.userPrincipal().roles()
-            .stream().map(RoleMapper.INSTANCE::fromValueObject).toList();
+        String role = RoleMapper.INSTANCE.fromValueObject(tokenClaims.userPrincipal().role());
         String subject = String.format("%s,%s",
             tokenClaims.userPrincipal().id(),
             tokenClaims.userPrincipal().email().value()
         );
         return Jwt.withTokenValue(token)
             .header("alg", "none")
-            .claim("scope", roles)
+            .claim("scope", role)
             .expiresAt(tokenClaims.expirationTime())
             .issuedAt(tokenClaims.creationTime())
             .subject(subject)

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeTokenClaimsCodecUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeTokenClaimsCodecUnitTests.java
@@ -8,10 +8,10 @@ import com.nimbleways.springboilerplate.testhelpers.configurations.TimeTestConfi
 @UnitTest
 public class FakeTokenClaimsCodecUnitTests extends TokenClaimsCodecPortContractTests {
 
-    private static final String TOKEN_WITH_ROLES_PLACEHOLDER = """
+    private static final String TOKEN_WITH_ROLE_PLACEHOLDER = """
         {"rand":"8cf92381-9492-42a2-8605-caca41be9aa3","tokenClaims":
         {"userPrincipal":{"id":"54cd8ce9-14d3-4568-8a80-f909388b58bf",
-        "email":{"value":"email"},"roles":%s},"creationTime":1708449075.514227600,
+        "email":{"value":"email"},"role":%s},"creationTime":1708449075.514227600,
         "expirationTime":1708449076.514227600}}""";
 
     @Override
@@ -20,17 +20,17 @@ public class FakeTokenClaimsCodecUnitTests extends TokenClaimsCodecPortContractT
     }
 
     @Override
-    protected AccessToken getTokenWithoutRoles() {
-        return new AccessToken(String.format(TOKEN_WITH_ROLES_PLACEHOLDER, "null"));
+    protected AccessToken getTokenWithoutRole() {
+        return new AccessToken(String.format(TOKEN_WITH_ROLE_PLACEHOLDER, "null"));
     }
 
     @Override
-    protected AccessToken getTokenWithInvalidRolesArrayClaim() {
-        return new AccessToken(String.format(TOKEN_WITH_ROLES_PLACEHOLDER, "[1, 2, 3]"));
+    protected AccessToken getTokenWithInvalidRoleArrayClaim() {
+        return new AccessToken(String.format(TOKEN_WITH_ROLE_PLACEHOLDER, "[1, 2, 3]"));
     }
 
     @Override
-    protected AccessToken getTokenWithInvalidRolesScalarClaim() {
-        return new AccessToken(String.format(TOKEN_WITH_ROLES_PLACEHOLDER, "10"));
+    protected AccessToken getTokenWithInvalidRoleScalarClaim() {
+        return new AccessToken(String.format(TOKEN_WITH_ROLE_PLACEHOLDER, "10"));
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeUserRepository.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeUserRepository.java
@@ -29,7 +29,7 @@ public class FakeUserRepository implements UserRepositoryPort, UserCredentialsRe
         }
         User user = new User(UUID.randomUUID(), userToCreate.name(), userToCreate.email(),
             userToCreate.creationDateTime(),
-            userToCreate.roles());
+            userToCreate.role());
         userTable.put(user.email(), new UserWithPassword(user, userToCreate.encodedPassword()));
         return user;
     }

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/database/jparepositories/TransactionalExampleIntegrationTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/database/jparepositories/TransactionalExampleIntegrationTests.java
@@ -2,6 +2,8 @@ package com.nimbleways.springboilerplate.common.infra.database.jparepositories;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
+import com.nimbleways.springboilerplate.common.infra.database.entities.RoleDbEntity;
 import com.nimbleways.springboilerplate.common.infra.database.entities.UserDbEntity;
 import com.nimbleways.springboilerplate.testhelpers.annotations.SetupDatabase;
 import java.time.Instant;
@@ -84,6 +86,7 @@ class TransactionalExampleIntegrationTests {
         user.password(password);
         user.name(email);
         user.createdAt(Instant.now());
+        user.role(RoleDbEntity.newFromRole(Role.USER));
         return user;
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/authentication/domain/ports/TokenClaimsCodecPortContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/authentication/domain/ports/TokenClaimsCodecPortContractTests.java
@@ -73,8 +73,8 @@ public abstract class TokenClaimsCodecPortContractTests {
     }
 
     @Test
-    void decoding_an_accesstoken_without_roles_throws_AccessTokenDecodingException() {
-        AccessToken token = getTokenWithoutRoles();
+    void decoding_an_accesstoken_without_role_throws_AccessTokenDecodingException() {
+        AccessToken token = getTokenWithoutRole();
 
         Exception exception = assertThrows(Exception.class,
             () -> tokenCodec.decodeWithoutExpirationValidation(token));
@@ -84,8 +84,8 @@ public abstract class TokenClaimsCodecPortContractTests {
     }
 
     @Test
-    void decoding_an_accesstoken_with_invalid_roles_array_claim_throws_AccessTokenDecodingException() {
-        AccessToken token = getTokenWithInvalidRolesArrayClaim();
+    void decoding_an_accesstoken_with_invalid_role_array_claim_throws_AccessTokenDecodingException() {
+        AccessToken token = getTokenWithInvalidRoleArrayClaim();
 
         Exception exception = assertThrows(Exception.class,
             () -> tokenCodec.decodeWithoutExpirationValidation(token));
@@ -95,8 +95,8 @@ public abstract class TokenClaimsCodecPortContractTests {
     }
 
     @Test
-    void decoding_an_accesstoken_with_invalid_roles_scalar_claim_throws_AccessTokenDecodingException() {
-        AccessToken token = getTokenWithInvalidRolesScalarClaim();
+    void decoding_an_accesstoken_with_invalid_role_scalar_claim_throws_AccessTokenDecodingException() {
+        AccessToken token = getTokenWithInvalidRoleScalarClaim();
 
         Exception exception = assertThrows(Exception.class,
             () -> tokenCodec.decodeWithoutExpirationValidation(token));
@@ -109,7 +109,7 @@ public abstract class TokenClaimsCodecPortContractTests {
     private TokenClaims getTokenClaims() {
         Instant now = Instant.now();
         return new TokenClaims(
-            aUserPrincipal().withRoles(Immutable.set.of(Role.USER)).build(),
+            aUserPrincipal().withRole(Role.USER).build(),
             adjustPrecision(now),
             adjustPrecision(now.plusSeconds(1))
         );
@@ -121,7 +121,7 @@ public abstract class TokenClaimsCodecPortContractTests {
     protected Instant adjustPrecision(Instant instant) {
         return instant;
     }
-    protected abstract AccessToken getTokenWithoutRoles();
-    protected abstract AccessToken getTokenWithInvalidRolesArrayClaim();
-    protected abstract AccessToken getTokenWithInvalidRolesScalarClaim();
+    protected abstract AccessToken getTokenWithoutRole();
+    protected abstract AccessToken getTokenWithInvalidRoleArrayClaim();
+    protected abstract AccessToken getTokenWithInvalidRoleScalarClaim();
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/authentication/domain/ports/TokenClaimsCodecPortContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/authentication/domain/ports/TokenClaimsCodecPortContractTests.java
@@ -4,7 +4,6 @@ import static com.nimbleways.springboilerplate.testhelpers.fixtures.UserPrincipa
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.TokenClaims;
 import com.nimbleways.springboilerplate.features.authentication.domain.exceptions.AccessTokenDecodingException;
 import com.nimbleways.springboilerplate.features.authentication.domain.valueobjects.AccessToken;

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getusers/GetUsersEndpointIntegrationTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getusers/GetUsersEndpointIntegrationTests.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
 import com.nimbleways.springboilerplate.testhelpers.BaseWebMvcIntegrationTests;
 import com.nimbleways.springboilerplate.features.users.domain.usecases.suts.GetUsersSut;

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getusers/GetUsersEndpointIntegrationTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getusers/GetUsersEndpointIntegrationTests.java
@@ -11,7 +11,6 @@ import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
 import com.nimbleways.springboilerplate.testhelpers.BaseWebMvcIntegrationTests;
 import com.nimbleways.springboilerplate.features.users.domain.usecases.suts.GetUsersSut;
-import org.eclipse.collections.api.set.ImmutableSet;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -28,8 +27,8 @@ class GetUsersEndpointIntegrationTests extends BaseWebMvcIntegrationTests {
     @Test
     void testGetUsersEndpoint() throws Exception {
         // GIVEN
-        User user1 = getUser("user1", "email1@test.com", Immutable.set.of(Role.ADMIN));
-        User user2 = getUser("user2", "email2@test.com", Immutable.set.of());
+        User user1 = getUser("user1", "email1@test.com", Role.ADMIN);
+        User user2 = getUser("user2", "email2@test.com", Role.USER);
 
         // WHEN
         mockMvc
@@ -55,12 +54,12 @@ class GetUsersEndpointIntegrationTests extends BaseWebMvcIntegrationTests {
             .andExpect(status().isForbidden());
     }
 
-    private User getUser(String name, String email, ImmutableSet<Role> roles) {
+    private User getUser(String name, String email, Role role) {
         return getUsersSut.userRepository().create(
             aNewUser()
                 .withName(name)
                 .withEmail(new Email(email))
-                .withRoles(roles)
+                .withRole(role)
                 .build()
         );
     }

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/signup/SignupEndpointIntegrationTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/signup/SignupEndpointIntegrationTests.java
@@ -29,14 +29,14 @@ class SignupEndpointIntegrationTests extends BaseWebMvcIntegrationTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                     {"name":"Name", "email":"email@test.com",
-                    "password":"password", "roles":["ADMIN"]}""")
+                    "password":"password", "role":"ADMIN"}""")
             )
 
         // THEN
             .andExpect(status().isCreated())
             .andExpect(content().json(String.format("""
                     {"id":"%s","name":"Name",
-                    "email":"email@test.com","roles":["ADMIN"]}""", getUserId().toString()))
+                    "email":"email@test.com","role":"ADMIN"}""", getUserId().toString()))
             );
     }
 

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/ports/UserRepositoryPortContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/ports/UserRepositoryPortContractTests.java
@@ -79,7 +79,7 @@ public abstract class UserRepositoryPortContractTests {
             user.email(),
             userCredential.get().encodedPassword(),
             user.createdAt(),
-            user.roles()
+            user.role()
         );
     }
 

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/SignupUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/SignupUseCaseUnitTests.java
@@ -51,7 +51,7 @@ class SignupUseCaseUnitTests {
         // THEN
         assertThat(user)
             .usingRecursiveComparison()
-            .ignoringFields("id", "roles.id")
+            .ignoringFields("id", "role.id")
             .isEqualTo(expectedUser);
     }
 
@@ -85,16 +85,16 @@ class SignupUseCaseUnitTests {
             signupCommand.name(),
             signupCommand.email(),
             sut.timeProvider().instant(),
-            signupCommand.roles()
+            signupCommand.role()
         );
     }
 
     @NotNull
     private static SignupCommand createSignupCommand() {
-        User inputUser = aUser().withRoles(Immutable.set.of(Role.ADMIN)).build();
+        User inputUser = aUser().withRole(Role.ADMIN).build();
         return new SignupCommand(inputUser.name(),
             inputUser.email(), "password",
-            inputUser.roles());
+            inputUser.role());
     }
 
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/SignupUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/SignupUseCaseUnitTests.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPassword;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
 import com.nimbleways.springboilerplate.features.users.domain.usecases.signup.SignupCommand;
 import com.nimbleways.springboilerplate.testhelpers.annotations.UnitTest;

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/NewUserFixture.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/NewUserFixture.java
@@ -5,14 +5,12 @@ import com.nimbleways.springboilerplate.common.domain.ports.TimeProviderPort;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakePasswordEncoder;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.users.domain.valueobjects.NewUser;
 import com.nimbleways.springboilerplate.testhelpers.configurations.TimeTestConfiguration;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.With;
-import org.eclipse.collections.api.set.ImmutableSet;
 import org.jetbrains.annotations.NotNull;
 
 public class NewUserFixture {
@@ -30,7 +28,7 @@ public class NewUserFixture {
         private String name = "name-" + id;
         private Email email = new Email("email-" + id + "@test.com");
         private String plainPassword = "password-" + id;
-        private ImmutableSet<Role> roles = Immutable.set.of();
+        private Role role = Role.USER;
         private TimeProviderPort timeProvider = TimeTestConfiguration.fixedTimeProvider();
         private PasswordEncoderPort passwordEncoder = FakePasswordEncoder.INSTANCE;
 
@@ -41,7 +39,7 @@ public class NewUserFixture {
                     email,
                 passwordEncoder.encode(plainPassword),
                 timeProvider.instant(),
-                roles);
+                role);
         }
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/UserFixture.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/UserFixture.java
@@ -3,14 +3,12 @@ package com.nimbleways.springboilerplate.testhelpers.fixtures;
 import com.nimbleways.springboilerplate.common.domain.ports.TimeProviderPort;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
 import com.nimbleways.springboilerplate.testhelpers.configurations.TimeTestConfiguration;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.With;
-import org.eclipse.collections.api.set.ImmutableSet;
 import org.jetbrains.annotations.NotNull;
 
 public class UserFixture {
@@ -28,7 +26,7 @@ public class UserFixture {
         private String name = "name";
         private String email = "email@test.com";
         private TimeProviderPort timeProvider = TimeTestConfiguration.fixedTimeProvider();
-        private ImmutableSet<Role> roles = Immutable.set.of();
+        private Role role = Role.USER;
 
         @NotNull
         public User build() {
@@ -37,7 +35,7 @@ public class UserFixture {
                     name,
                     new Email(email),
                     timeProvider.instant(),
-                    roles);
+                    role);
         }
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/UserPrincipalFixture.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/UserPrincipalFixture.java
@@ -2,13 +2,11 @@ package com.nimbleways.springboilerplate.testhelpers.fixtures;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
-import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserPrincipal;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.With;
-import org.eclipse.collections.api.set.ImmutableSet;
 import org.jetbrains.annotations.NotNull;
 
 public class UserPrincipalFixture {
@@ -24,14 +22,14 @@ public class UserPrincipalFixture {
     public static final class Builder {
         private UUID id = UUID.randomUUID();
         private String email = "email@test.com";
-        private ImmutableSet<Role> roles = Immutable.set.of();
+        private Role role = Role.USER;
 
         @NotNull
         public UserPrincipal build() {
             return new UserPrincipal(
                     id,
                     new Email(email),
-                    roles);
+                    role);
         }
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/helpers/Mapper.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/helpers/Mapper.java
@@ -6,6 +6,6 @@ import com.nimbleways.springboilerplate.features.users.domain.entities.User;
 public class Mapper {
 
     public static UserPrincipal toUserPrincipal(User user) {
-        return new UserPrincipal(user.id(), user.email(), user.roles());
+        return new UserPrincipal(user.id(), user.email(), user.role());
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/transverse/archunit/infra/JpaRulesUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/transverse/archunit/infra/JpaRulesUnitTests.java
@@ -47,7 +47,8 @@ public class JpaRulesUnitTests {
                     .or()
                     .areAnnotatedWith(Embeddable.class)
                     .should()
-                    .beAnnotatedWith(NotNull.class);
+                    .beAnnotatedWith(NotNull.class)
+                    .allowEmptyShould(true);
 
     @ArchTest
     private final ArchRule fields_annotated_with_GeneratedValue_should_be_annotated_with_nullable =

--- a/api/src/test/java/com/nimbleways/springboilerplate/transverse/e2e/E2ETests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/transverse/e2e/E2ETests.java
@@ -15,7 +15,7 @@ class E2ETests extends BaseE2ETests {
         // ----------- Sign up new user ------------//
         RequestEntity<String> request = post("/auth/signup").body("""
             {"name":"Name", "email":"email@test.com",
-            "password":"password1", "roles":["ADMIN"]}""");
+            "password":"password1", "role":"ADMIN"}""");
         ResponseEntity<String> response = restTemplate.exchange(request, String.class);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
 


### PR DESCRIPTION
## Summary
- Changed roles to role; now the user will only have one role at a time.
- Added database migrations to sync with the changes.
- Added `allowEmptyShould` to `relationship_collection_attributes_must_be_notnull` to address cases where no `Entity` or `Embeddable` contains an `Iterable` with `OneToMany` or `ManyToMany`, which was causing the tests to fail.

## Trello Card
- Closes #36

## Breaking Changes
❗The `roles` field has been replaced entirely by `role`. Any external references to roles will now be invalid.