### PR TITLE
feat: get auth user

### DIFF
--- a/api/src/main/java/com/nimbleways/springboilerplate/common/domain/valueobjects/Money.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/domain/valueobjects/Money.java
@@ -1,0 +1,4 @@
+package com.nimbleways.springboilerplate.common.domain.valueobjects;
+
+public record Money(double value) {
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/UserDbEntity.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/UserDbEntity.java
@@ -2,6 +2,7 @@ package com.nimbleways.springboilerplate.common.infra.database.entities;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPassword;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserCredential;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserPrincipal;
@@ -61,6 +62,8 @@ public class UserDbEntity {
     @NotNull
     private RoleDbEntity role;
 
+    private double balance;
+
     public static UserDbEntity from(NewUser newUser) {
         RoleDbEntity role = RoleDbEntity.newFromRole(newUser.role());
         final UserDbEntity userDbEntity = new UserDbEntity();
@@ -70,6 +73,7 @@ public class UserDbEntity {
         userDbEntity.createdAt(newUser.creationDateTime());
         userDbEntity.employmentDate(newUser.employmentDate());
         userDbEntity.role(role);
+        userDbEntity.balance(0.);
         return userDbEntity;
     }
 
@@ -80,7 +84,8 @@ public class UserDbEntity {
                 new Email(email),
                 createdAt,
                 employmentDate,
-                getRole()
+                getRole(),
+                new Money(balance)
         );
     }
 

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getauthenticateduser/AuthenticatedUserResponse.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getauthenticateduser/AuthenticatedUserResponse.java
@@ -1,0 +1,13 @@
+package com.nimbleways.springboilerplate.features.users.api.endpoints.getauthenticateduser;
+
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+
+public record AuthenticatedUserResponse(String name, String email, double balance) {
+    public static AuthenticatedUserResponse from(User user) {
+        return new AuthenticatedUserResponse(
+                user.name(),
+                user.email().value(),
+                user.balance().value()
+        );
+    }
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getauthenticateduser/GetAuthenticatedUserEndpoint.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getauthenticateduser/GetAuthenticatedUserEndpoint.java
@@ -1,0 +1,28 @@
+package com.nimbleways.springboilerplate.features.users.api.endpoints.getauthenticateduser;
+
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+import com.nimbleways.springboilerplate.features.users.domain.usecases.getauthenticateduser.GetAuthenticatedUserUseCase;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GetAuthenticatedUserEndpoint {
+    private static final String URL = "/auth/me";
+
+    private final GetAuthenticatedUserUseCase getAuthenticatedUserUseCase;
+
+    public GetAuthenticatedUserEndpoint(final GetAuthenticatedUserUseCase getAuthenticatedUserUseCase) {
+        this.getAuthenticatedUserUseCase = getAuthenticatedUserUseCase;
+    }
+
+    @GetMapping(URL)
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.OK)
+    public AuthenticatedUserResponse getAuthenticatedUser() {
+        User user = getAuthenticatedUserUseCase.handle();
+        return AuthenticatedUserResponse.from(user);
+    }
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/entities/User.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/entities/User.java
@@ -1,6 +1,7 @@
 package com.nimbleways.springboilerplate.features.users.domain.entities;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 
 import java.time.Instant;
@@ -12,6 +13,7 @@ public record User(
         Email email,
         Instant createdAt,
         Instant employmentDate,
-        Role role
+        Role role,
+        Money balance
 ){
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/ports/SecurityContextPort.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/ports/SecurityContextPort.java
@@ -1,0 +1,9 @@
+package com.nimbleways.springboilerplate.features.users.domain.ports;
+
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
+
+import java.util.Optional;
+
+public interface SecurityContextPort {
+    Optional<Email> getCurrentUserEmail();
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/usecases/getauthenticateduser/GetAuthenticatedUserUseCase.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/users/domain/usecases/getauthenticateduser/GetAuthenticatedUserUseCase.java
@@ -1,0 +1,22 @@
+package com.nimbleways.springboilerplate.features.users.domain.usecases.getauthenticateduser;
+
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+import com.nimbleways.springboilerplate.features.users.domain.ports.SecurityContextPort;
+import com.nimbleways.springboilerplate.features.users.domain.ports.UserRepositoryPort;
+
+public class GetAuthenticatedUserUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+    private final SecurityContextPort securityContextPort;
+
+    public GetAuthenticatedUserUseCase(UserRepositoryPort userRepositoryPort, SecurityContextPort securityContextPort) {
+        this.userRepositoryPort = userRepositoryPort;
+        this.securityContextPort = securityContextPort;
+    }
+
+    public User handle() {
+        Email email = securityContextPort.getCurrentUserEmail().orElseThrow();
+        return userRepositoryPort.findByEmail(email).orElseThrow();
+    }
+}

--- a/api/src/main/resources/db/changelog-master.yaml
+++ b/api/src/main/resources/db/changelog-master.yaml
@@ -28,3 +28,6 @@ databaseChangeLog:
   - include:
       file: changelog/20250303-094402-add-employment-date-to-user.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20250303-153105-add-balance-to-user.yaml
+      relativeToChangelogFile: true

--- a/api/src/main/resources/db/changelog/20250303-153105-add-balance-to-user.yaml
+++ b/api/src/main/resources/db/changelog/20250303-153105-add-balance-to-user.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+- changeSet:
+    id: 1741015887961-1
+    author: Yassine (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: balance
+            type: FLOAT(53)
+        tableName: users
+

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/SpringJwtDecoderContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/SpringJwtDecoderContractTests.java
@@ -94,7 +94,7 @@ public abstract class SpringJwtDecoderContractTests {
     protected abstract String getMalformedToken();
 
     @NotNull
-    protected TimeProviderPort getTimeProvider() {
+    protected static TimeProviderPort getTimeProvider() {
         return TimeTestConfiguration.fixedTimeProvider();
     }
 

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeAuthentication.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeAuthentication.java
@@ -1,0 +1,49 @@
+package com.nimbleways.springboilerplate.common.infra.adapters.fakes;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
+
+public class FakeAuthentication implements Authentication {
+    private final Object principal;
+
+    public FakeAuthentication(@Nullable Object principal) {
+        this.principal = principal;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    // Other methods can return dummy values (not used in our tests)
+    @Override
+    public ImmutableList<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) {
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeJwt.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeJwt.java
@@ -1,0 +1,24 @@
+package com.nimbleways.springboilerplate.common.infra.adapters.fakes;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Instant;
+import java.util.Collections;
+
+public class FakeJwt extends Jwt {
+    private final ImmutableMap<String, Object> claims;
+
+    public FakeJwt(ImmutableMap<String, Object> claims) {
+        super("token", Instant.now(), Instant.now().plusSeconds(3600),
+                Collections.singletonMap("alg", "none"), claims);
+        this.claims = claims;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> @Nullable T getClaim(String claim) {
+        return (T) claims.get(claim);
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeUserRepository.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakeUserRepository.java
@@ -4,6 +4,7 @@ import static com.nimbleways.springboilerplate.testhelpers.helpers.Mapper.toUser
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPassword;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
 import com.nimbleways.springboilerplate.common.utils.collections.Mutable;
 import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserCredential;
 import com.nimbleways.springboilerplate.features.authentication.domain.ports.UserCredentialsRepositoryPort;
@@ -30,7 +31,7 @@ public class FakeUserRepository implements UserRepositoryPort, UserCredentialsRe
         User user = new User(UUID.randomUUID(), userToCreate.name(), userToCreate.email(),
             userToCreate.creationDateTime(),
             userToCreate.employmentDate(),
-            userToCreate.role());
+            userToCreate.role(), new Money(0));
         userTable.put(user.email(), new UserWithPassword(user, userToCreate.encodedPassword()));
         return user;
     }

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getauthenticateduser/GetAuthenticatedUserEndpointIntegrationTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/api/endpoints/getauthenticateduser/GetAuthenticatedUserEndpointIntegrationTests.java
@@ -1,0 +1,48 @@
+package com.nimbleways.springboilerplate.features.users.api.endpoints.getauthenticateduser;
+
+import com.nimbleways.springboilerplate.features.authentication.domain.valueobjects.UserTokens;
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+import com.nimbleways.springboilerplate.features.users.domain.usecases.suts.GetAuthenticatedUserSut;
+import com.nimbleways.springboilerplate.testhelpers.BaseWebMvcIntegrationTests;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+
+import static com.nimbleways.springboilerplate.testhelpers.helpers.TokenHelpers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = GetAuthenticatedUserEndpoint.class)
+@Import({GetAuthenticatedUserSut.class})
+class GetAuthenticatedUserEndpointIntegrationTests extends BaseWebMvcIntegrationTests {
+    public static final String GET_AUTHENTICATED_ENDPOINT = "/auth/me";
+
+    @Autowired
+    private GetAuthenticatedUserSut getAuthenticatedUserSut;
+
+    @Test
+    void returns_authenticated_user_when_get_authenticated_user_succeed() throws Exception {
+        // GIVEN
+        GetAuthenticatedUserSut.TestData testData = getAuthenticatedUserSut.addUserAndSessionToRepository();
+        UserTokens userTokens = testData.userTokens();
+        User user = testData.user();
+        String exptectedJson = expectedUserContent(user);
+
+        // WHEN
+        mockMvc
+                .perform(
+                        get(GET_AUTHENTICATED_ENDPOINT)
+                                .cookie(new Cookie("accessToken", urlEncodeAccessToken(userTokens)))
+                )
+
+                // THEN
+                .andExpect(status().isOk())
+                .andExpect(content().string(exptectedJson));
+    }
+
+    private String expectedUserContent(User user) {
+        return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"balance\":%.1f}", user.name(), user.email().value(), user.balance().value());
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/ports/UserRepositoryPortContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/ports/UserRepositoryPortContractTests.java
@@ -48,7 +48,16 @@ public abstract class UserRepositoryPortContractTests {
         User user = userRepository.create(newUser);
 
         assertEquals(List.of(user), userRepository.findAll());
-        assertEquals(Optional.of(user), userRepository.findByEmail(user.email()));
+    }
+
+    @Test
+    void finding_the_newly_created_user_after_creating_one() {
+        NewUser newUser = aNewUser().build();
+
+        User user = userRepository.create(newUser);
+        Optional<User> result = userRepository.findByEmail(user.email());
+
+        assertEquals(Optional.of(user), result);
     }
 
     @Test

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/GetAuthenticatedUserUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/GetAuthenticatedUserUseCaseUnitTests.java
@@ -1,0 +1,26 @@
+package com.nimbleways.springboilerplate.features.users.domain.usecases;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+import com.nimbleways.springboilerplate.features.users.domain.usecases.suts.GetAuthenticatedUserSut;
+import com.nimbleways.springboilerplate.testhelpers.annotations.UnitTest;
+import com.nimbleways.springboilerplate.testhelpers.utils.Instance;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class GetAuthenticatedUserUseCaseUnitTests {
+    private final GetAuthenticatedUserSut sut = Instance.create(GetAuthenticatedUserSut.class);
+
+    @Test
+    void returns_authenticated_user() {
+        // GIVEN
+        User user = sut.addUserAndSessionToRepository().user();
+
+        // WHEN
+        User result = sut.handle();
+
+        // THEN
+        assertEquals(user, result);
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/SignupUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/SignupUseCaseUnitTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.EncodedPassword;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
@@ -85,7 +86,8 @@ class SignupUseCaseUnitTests {
             signupCommand.email(),
             sut.timeProvider().instant(),
             sut.employmentDatePort().getEmploymentDate(signupCommand.email()),
-            signupCommand.role()
+            signupCommand.role(),
+            new Money(0)
         );
     }
 

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/suts/GetAuthenticatedUserSut.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/users/domain/usecases/suts/GetAuthenticatedUserSut.java
@@ -1,0 +1,76 @@
+package com.nimbleways.springboilerplate.features.users.domain.usecases.suts;
+
+import com.nimbleways.springboilerplate.common.domain.ports.TimeProviderPort;
+import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakeRandomGenerator;
+import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakeTokenClaimsCodec;
+import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakeUserRepository;
+import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakeUserSessionRepository;
+import com.nimbleways.springboilerplate.features.authentication.domain.entities.TokenClaims;
+import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserPrincipal;
+import com.nimbleways.springboilerplate.features.authentication.domain.entities.UserSession;
+import com.nimbleways.springboilerplate.features.authentication.domain.properties.TokenProperties;
+import com.nimbleways.springboilerplate.features.authentication.domain.valueobjects.UserTokens;
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+import com.nimbleways.springboilerplate.features.users.domain.usecases.getauthenticateduser.GetAuthenticatedUserUseCase;
+import com.nimbleways.springboilerplate.testhelpers.configurations.PropertiesTestConfiguration;
+import com.nimbleways.springboilerplate.testhelpers.configurations.TimeTestConfiguration;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Import;
+
+import java.time.Instant;
+
+import static com.nimbleways.springboilerplate.testhelpers.fixtures.NewUserFixture.aNewUser;
+import static com.nimbleways.springboilerplate.testhelpers.fixtures.SimpleFixture.aUserTokens;
+import static com.nimbleways.springboilerplate.testhelpers.helpers.Mapper.toUserPrincipal;
+
+@Getter
+@Import({
+        GetAuthenticatedUserUseCase.class,
+        FakeUserSessionRepository.class,
+        FakeUserRepository.class,
+        FakeTokenClaimsCodec.class,
+        PropertiesTestConfiguration.class,
+        TimeTestConfiguration.class,
+        FakeRandomGenerator.class
+})
+@RequiredArgsConstructor
+public class GetAuthenticatedUserSut {
+    @Getter(AccessLevel.NONE)
+    private final GetAuthenticatedUserUseCase useCase;
+
+    private final FakeUserRepository userRepository;
+    private final FakeUserSessionRepository userSessionRepository;
+    private final TokenProperties tokenProperties;
+    private final FakeTokenClaimsCodec tokenGenerator;
+    private final TimeProviderPort timeProvider;
+
+    public User handle() {
+        return useCase.handle();
+    }
+
+    @NotNull
+    public TestData addUserAndSessionToRepository() {
+        User user = userRepository().create(aNewUser().build());
+        TestData testData = createUserSessionAndTokens(user);
+        userSessionRepository().create(testData.userSession());
+        return testData;
+    }
+
+    @NotNull
+    private TestData createUserSessionAndTokens(User user) {
+        Instant now = timeProvider.instant();
+        UserPrincipal userPrincipal = toUserPrincipal(user);
+        TokenClaims tokenClaims = new TokenClaims(userPrincipal, now, now.plusSeconds(1));
+        UserTokens userTokens = aUserTokens(tokenGenerator.encode(tokenClaims));
+        UserSession userSession = new UserSession(
+                userTokens.refreshToken(),
+                now.plus(tokenProperties.refreshTokenValidityDuration()),
+                userPrincipal);
+        return new TestData(userSession, userTokens, user);
+    }
+
+    public record TestData(UserSession userSession, UserTokens userTokens, User user) {}
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/NewUserFixture.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/NewUserFixture.java
@@ -39,7 +39,7 @@ public class NewUserFixture {
         public NewUser build() {
             return new NewUser(
                 name,
-                    email,
+                email,
                 passwordEncoder.encode(plainPassword),
                 timeProvider.instant(),
                 employmentDateProvider.getEmploymentDate(email),

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/UserFixture.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/UserFixture.java
@@ -3,6 +3,7 @@ package com.nimbleways.springboilerplate.testhelpers.fixtures;
 import com.nimbleways.springboilerplate.common.domain.ports.EmploymentDatePort;
 import com.nimbleways.springboilerplate.common.domain.ports.TimeProviderPort;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Email;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Role;
 import com.nimbleways.springboilerplate.features.users.domain.entities.User;
 import com.nimbleways.springboilerplate.testhelpers.configurations.EmploymentDateTestConfiguration;
@@ -40,7 +41,8 @@ public class UserFixture {
                     userEmail,
                     timeProvider.instant(),
                     employmentDateProvider.getEmploymentDate(userEmail),
-                    role);
+                    role,
+                    new Money(0));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adding `email` to the jwt claims.
- Add `balance` field to the user.
- Add functionality to get current authenticated user.
- Adding tests for the functionality to get authenticated user.
- Adding tests for jwt to reach 100% test coverage.

## Trello Card
- Closes [TC#27](https://trello.com/c/oeMPaLyS/27-4-etq-theodoer-une-fois-connect%C3%A9-je-vois-mon-avatar-avec-mes-initiales-et-quand-je-clique-dessus-je-vois-mon-pr%C3%A9nom-mon-nom-et-m)