### PR TITLE
feat: purchase-coworkers

### DIFF
--- a/api/src/main/java/com/nimbleways/springboilerplate/common/domain/valueobjects/StarRating.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/domain/valueobjects/StarRating.java
@@ -1,0 +1,4 @@
+package com.nimbleways.springboilerplate.common.domain.valueobjects;
+
+public record StarRating(int value) {
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/adapters/PurchaseRepository.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/adapters/PurchaseRepository.java
@@ -16,35 +16,42 @@ import java.util.stream.Stream;
 
 @Component
 public class PurchaseRepository implements PurchaseRepositoryPort {
-    private final JpaPurchaseRepository purchaseRepository;
-    private final JpaUserRepository userRepository;
+	private final JpaPurchaseRepository purchaseRepository;
+	private final JpaUserRepository userRepository;
 
-    public PurchaseRepository(JpaPurchaseRepository purchaseRepository, JpaUserRepository userRepository) {
-        this.purchaseRepository = purchaseRepository;
-        this.userRepository = userRepository;
-    }
+	public PurchaseRepository(JpaPurchaseRepository purchaseRepository, JpaUserRepository userRepository) {
+		this.purchaseRepository = purchaseRepository;
+		this.userRepository = userRepository;
+	}
 
-    @Override
-    @Transactional
-    public Purchase create(NewPurchase purchase) {
-        UserDbEntity user = userRepository.findById(purchase.userId()).orElseThrow();
-        PurchaseDbEntity entity = PurchaseDbEntity.from(purchase, user);
+	@Override
+	@Transactional
+	public Purchase create(NewPurchase purchase) {
+		UserDbEntity user = userRepository.findById(purchase.userId()).orElseThrow();
+		PurchaseDbEntity entity = PurchaseDbEntity.from(purchase, user);
 
-        entity = purchaseRepository.saveAndFlush(entity);
-        return entity.toPurchase();
-    }
+		entity = purchaseRepository.saveAndFlush(entity);
+		return entity.toPurchase();
+	}
 
-    @Override
-    public Optional<Purchase> findById(UUID purchaseId) {
-        return purchaseRepository
-                .findById(purchaseId)
-                .map(PurchaseDbEntity::toPurchase);
-    }
+	@Override
+	public Optional<Purchase> findById(UUID purchaseId) {
+		return purchaseRepository
+			.findById(purchaseId)
+			.map(PurchaseDbEntity::toPurchase);
+	}
 
-    @Override
-    public Stream<Purchase> findByUserId(UUID userId) {
-        return purchaseRepository
-                .streamByUser_Id(userId)
-                .map(PurchaseDbEntity::toPurchase);
-    }
+	@Override
+	public Stream<Purchase> findByUserId(UUID userId) {
+		return purchaseRepository
+			.streamByUser_Id(userId)
+			.map(PurchaseDbEntity::toPurchase);
+	}
+
+	@Override
+	public Stream<Purchase> findCoworkersPurchases(UUID userId) {
+		return purchaseRepository
+			.findOthersPurchases(userId)
+			.map(PurchaseDbEntity::toPurchase);
+	}
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/PurchaseDbEntity.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/entities/PurchaseDbEntity.java
@@ -1,6 +1,8 @@
 package com.nimbleways.springboilerplate.common.infra.database.entities;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
+import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
 import com.nimbleways.springboilerplate.features.purchases.domain.valueobjects.NewPurchase;
 import jakarta.persistence.*;
@@ -12,6 +14,7 @@ import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.UUID;
 
 @Entity
@@ -36,9 +39,25 @@ public class PurchaseDbEntity {
     private Instant purchaseDate;
 
     @NotNull
+    private String name;
+
+    @NotNull
+    private String model;
+
+    @NotNull
     private String brand;
 
+    @NotNull
+    private String store;
+
+    @ElementCollection
+    @Column(name = "images")
+    @NotNull
+    private Collection<String> images;
+
     private double price;
+
+    private int rating;
 
     public static PurchaseDbEntity from(NewPurchase purchase, UserDbEntity user) {
         PurchaseDbEntity entity = new PurchaseDbEntity();
@@ -46,16 +65,26 @@ public class PurchaseDbEntity {
         entity.purchaseDate(purchase.purchaseDate());
         entity.brand(purchase.brand());
         entity.price(purchase.price().value());
+        entity.rating(purchase.rating().value());
+        entity.model(purchase.model());
+        entity.store(purchase.store());
+        entity.name(purchase.name());
+        entity.images(purchase.images().toList());
         return entity;
     }
 
     public Purchase toPurchase() {
         return new Purchase(
-                id,
-                user.id(),
-                purchaseDate,
-                brand,
-                new Money(price)
+            id,
+            user.id(),
+            name,
+            purchaseDate,
+            brand,
+            model,
+            store,
+            Immutable.collectList(this.images, String::new),
+            new Money(price),
+            new StarRating(rating)
         );
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/jparepositories/JpaPurchaseRepository.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/jparepositories/JpaPurchaseRepository.java
@@ -2,6 +2,7 @@ package com.nimbleways.springboilerplate.common.infra.database.jparepositories;
 
 import com.nimbleways.springboilerplate.common.infra.database.entities.PurchaseDbEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
@@ -9,5 +10,8 @@ import java.util.stream.Stream;
 
 @Repository
 public interface JpaPurchaseRepository extends JpaRepository<PurchaseDbEntity, UUID> {
-    Stream<PurchaseDbEntity> streamByUser_Id(UUID id);
+	Stream<PurchaseDbEntity> streamByUser_Id(UUID id);
+
+	@Query("SELECT p FROM PurchaseDbEntity p WHERE p.user.id != :userId")
+	Stream<PurchaseDbEntity> findOthersPurchases(UUID id);
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/jparepositories/JpaPurchaseRepository.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/common/infra/database/jparepositories/JpaPurchaseRepository.java
@@ -13,5 +13,5 @@ public interface JpaPurchaseRepository extends JpaRepository<PurchaseDbEntity, U
 	Stream<PurchaseDbEntity> streamByUser_Id(UUID id);
 
 	@Query("SELECT p FROM PurchaseDbEntity p WHERE p.user.id != :userId")
-	Stream<PurchaseDbEntity> findOthersPurchases(UUID id);
+	Stream<PurchaseDbEntity> findOthersPurchases(UUID userId);
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/createpurchase/CreatePurchaseRequest.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/createpurchase/CreatePurchaseRequest.java
@@ -1,27 +1,52 @@
 package com.nimbleways.springboilerplate.features.purchases.api.endpoints.createpurchase;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
 import com.nimbleways.springboilerplate.features.purchases.domain.usecases.createpurchase.CreatePurchaseCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.hibernate.validator.constraints.Range;
 
 import java.util.UUID;
 
 public record CreatePurchaseRequest(
-        @NotBlank
-        String userId,
-        @NotBlank
-        String brand,
-        @Range(min = 0)
-        @NotNull
-        Double price
+    @NotBlank
+    String userId,
+
+    @NotBlank
+    String name,
+
+    @NotBlank
+    String brand,
+
+    @NotBlank
+    String model,
+
+    @NotBlank
+    String store,
+
+    @NotNull
+    ImmutableList<String> images,
+
+    @Range(min = 0)
+    @NotNull
+    Double price,
+
+    @Range(min = 0, max = 5)
+    @NotNull
+    Integer rating
 ) {
     public CreatePurchaseCommand toCommand() {
         return new CreatePurchaseCommand(
-                UUID.fromString(userId),
-                brand,
-                new Money(price)
+            UUID.fromString(userId),
+            name,
+            brand,
+            model,
+            store,
+            images,
+            new Money(price),
+            new StarRating(rating)
         );
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseEndpoint.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseEndpoint.java
@@ -1,0 +1,39 @@
+package com.nimbleways.springboilerplate.features.purchases.api.endpoints.getcoworkerspurchase;
+
+import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase.GetCoworkersPurchaseCommand;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase.GetCoworkersPurchaseUseCase;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.stream.Stream;
+
+@RestController
+public class GetCoworkersPurchaseEndpoint {
+    private final static String URL = "/purchases/getcoworkers";
+
+    private final GetCoworkersPurchaseUseCase getCoworkersPurchaseUseCase;
+
+    public GetCoworkersPurchaseEndpoint(GetCoworkersPurchaseUseCase getCoworkersPurchaseUseCase) {
+        this.getCoworkersPurchaseUseCase = getCoworkersPurchaseUseCase;
+    }
+
+
+    @GetMapping(URL)
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.OK)
+    @Transactional(readOnly = true)
+    public GetCoworkersPurchaseResponse getCoworkersPurchase(
+        @RequestBody @Valid GetCoworkersPurchaseRequest request) {
+        GetCoworkersPurchaseCommand command = request.toCommand();
+        try (Stream<Purchase> purchases = getCoworkersPurchaseUseCase.handle(command)) {
+            return GetCoworkersPurchaseResponse.from(purchases);
+        }
+    }
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseRequest.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseRequest.java
@@ -1,0 +1,15 @@
+package com.nimbleways.springboilerplate.features.purchases.api.endpoints.getcoworkerspurchase;
+
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase.GetCoworkersPurchaseCommand;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record GetCoworkersPurchaseRequest(
+    @NotBlank
+    String userId
+) {
+    public GetCoworkersPurchaseCommand toCommand() {
+        return new GetCoworkersPurchaseCommand(UUID.fromString(userId));
+    }
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseResponse.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseResponse.java
@@ -1,0 +1,69 @@
+package com.nimbleways.springboilerplate.features.purchases.api.endpoints.getcoworkerspurchase;
+
+import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/*
+
+public record Purchase(
+        UUID id,
+        UUID userId,
+
+        String name,
+        Instant purchaseDate,
+
+        String brand,
+        String model,
+        String store,
+
+        ImmutableList<String> images,
+
+        Money price
+) {
+}
+
+ */
+public final class GetCoworkersPurchaseResponse extends ArrayList<GetCoworkersPurchaseResponse.Item> {
+    public record Item(
+        String id,
+        String userId,
+        String name,
+        String purchaseDate,
+
+        String brand,
+        String model,
+        String store,
+
+        ArrayList<String> images,
+
+        double price,
+        int rating
+    ) {
+        public static Item from(Purchase purchase) {
+            return new Item(
+                purchase.id().toString(),
+                purchase.userId().toString(),
+                purchase.name(),
+                purchase.purchaseDate().toString(),
+
+                purchase.brand(),
+                purchase.model(),
+                purchase.store(),
+
+                new ArrayList<>(purchase.images().toList()),
+
+                purchase.price().value(),
+                purchase.rating().value()
+            );
+        }
+    }
+
+    public static GetCoworkersPurchaseResponse from(Stream<Purchase> purchases) {
+        return purchases
+            .map(Item::from)
+            .collect(Collectors.toCollection(GetCoworkersPurchaseResponse::new));
+    }
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getpurchase/GetPurchaseResponse.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getpurchase/GetPurchaseResponse.java
@@ -2,16 +2,36 @@ package com.nimbleways.springboilerplate.features.purchases.api.endpoints.getpur
 
 import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
 
+import java.util.ArrayList;
+
 public record GetPurchaseResponse(
-        String id,
-        String userId,
-        String purchaseDate
+	String id,
+	String userId,
+	String name,
+	String purchaseDate,
+
+	String brand,
+	String model,
+	String store,
+
+	ArrayList<String> images,
+
+	double price
 ) {
-    public static GetPurchaseResponse from(Purchase purchase) {
-        return new GetPurchaseResponse(
-                purchase.id().toString(),
-                purchase.userId().toString(),
-                purchase.purchaseDate().toString()
-        );
-    }
+	public static GetPurchaseResponse from(Purchase purchase) {
+		return new GetPurchaseResponse(
+			purchase.id().toString(),
+			purchase.userId().toString(),
+			purchase.name(),
+			purchase.purchaseDate().toString(),
+
+			purchase.brand(),
+			purchase.model(),
+			purchase.store(),
+
+			new ArrayList<>(purchase.images().toList()),
+
+			purchase.price().value()
+		);
+	}
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getpurchases/GetPurchasesResponse.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getpurchases/GetPurchasesResponse.java
@@ -7,21 +7,41 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class GetPurchasesResponse extends ArrayList<GetPurchasesResponse.Item> {
-    public record Item(
-            String id,
-            String purchaseDate
-    ) {
-        public static Item from(Purchase purchase) {
-            return new Item(
-                    purchase.id().toString(),
-                    purchase.purchaseDate().toString()
-            );
-        }
-    }
+	public record Item(
+		String id,
+		String userId,
+		String name,
+		String purchaseDate,
 
-    public static GetPurchasesResponse from(Stream<Purchase> purchases) {
-        return purchases
-                .map(Item::from)
-                .collect(Collectors.toCollection(GetPurchasesResponse::new));
-    }
+		String brand,
+		String model,
+		String store,
+
+		ArrayList<String> images,
+
+		double price
+	) {
+		public static Item from(Purchase purchase) {
+			return new Item(
+				purchase.id().toString(),
+				purchase.userId().toString(),
+				purchase.name(),
+				purchase.purchaseDate().toString(),
+
+				purchase.brand(),
+				purchase.model(),
+				purchase.store(),
+
+				new ArrayList<>(purchase.images().toList()),
+
+				purchase.price().value()
+			);
+		}
+	}
+
+	public static GetPurchasesResponse from(Stream<Purchase> purchases) {
+		return purchases
+			.map(Item::from)
+			.collect(Collectors.toCollection(GetPurchasesResponse::new));
+	}
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/entities/Purchase.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/entities/Purchase.java
@@ -1,15 +1,26 @@
 package com.nimbleways.springboilerplate.features.purchases.domain.entities;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
+import org.eclipse.collections.api.list.ImmutableList;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record Purchase(
-        UUID id,
-        UUID userId,
-        Instant purchaseDate,
-        String brand,
-        Money price
+	UUID id,
+	UUID userId,
+
+	String name,
+	Instant purchaseDate,
+
+	String brand,
+	String model,
+	String store,
+
+	ImmutableList<String> images,
+
+	Money price,
+	StarRating rating
 ) {
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/ports/PurchaseRepositoryPort.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/ports/PurchaseRepositoryPort.java
@@ -13,4 +13,6 @@ public interface PurchaseRepositoryPort {
     Optional<Purchase> findById(UUID purchaseId);
 
     Stream<Purchase> findByUserId(UUID userId);
+
+    Stream<Purchase> findCoworkersPurchases(UUID userId);
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/createpurchase/CreatePurchaseCommand.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/createpurchase/CreatePurchaseCommand.java
@@ -1,22 +1,38 @@
 package com.nimbleways.springboilerplate.features.purchases.domain.usecases.createpurchase;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
 import com.nimbleways.springboilerplate.features.purchases.domain.valueobjects.NewPurchase;
+import org.eclipse.collections.api.list.ImmutableList;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record CreatePurchaseCommand(
-        UUID userId,
-        String brand,
-        Money price
+    UUID userId,
+
+    String name,
+
+    String brand,
+    String model,
+    String store,
+
+    ImmutableList<String> images,
+
+    Money price,
+    StarRating rating
 ) {
     public NewPurchase toNewPurchase(Instant purchaseDate) {
         return new NewPurchase(
-                userId,
-                purchaseDate,
-                brand,
-                price
+            userId,
+            name,
+            purchaseDate,
+            brand,
+            model,
+            store,
+            images,
+            price,
+            rating
         );
     }
 }

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/getcoworkerspurchase/GetCoworkersPurchaseCommand.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/getcoworkerspurchase/GetCoworkersPurchaseCommand.java
@@ -1,0 +1,8 @@
+package com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase;
+
+import java.util.UUID;
+
+public record GetCoworkersPurchaseCommand(
+    UUID userId
+) {
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/getcoworkerspurchase/GetCoworkersPurchaseUseCase.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/getcoworkerspurchase/GetCoworkersPurchaseUseCase.java
@@ -1,0 +1,18 @@
+package com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase;
+
+import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
+import com.nimbleways.springboilerplate.features.purchases.domain.ports.PurchaseRepositoryPort;
+
+import java.util.stream.Stream;
+
+public class GetCoworkersPurchaseUseCase {
+	private final PurchaseRepositoryPort purchaseRepository;
+
+	public GetCoworkersPurchaseUseCase(PurchaseRepositoryPort purchaseRepository) {
+		this.purchaseRepository = purchaseRepository;
+	}
+
+	public Stream<Purchase> handle(GetCoworkersPurchaseCommand command) {
+		return purchaseRepository.findCoworkersPurchases(command.userId());
+	}
+}

--- a/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/valueobjects/NewPurchase.java
+++ b/api/src/main/java/com/nimbleways/springboilerplate/features/purchases/domain/valueobjects/NewPurchase.java
@@ -1,14 +1,25 @@
 package com.nimbleways.springboilerplate.features.purchases.domain.valueobjects;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
+import org.eclipse.collections.api.list.ImmutableList;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record NewPurchase(
         UUID userId,
+
+        String name,
         Instant purchaseDate,
+
         String brand,
-        Money price
+        String model,
+        String store,
+
+        ImmutableList<String> images,
+
+        Money price,
+        StarRating rating
 ) {
 }

--- a/api/src/main/resources/db/changelog-master.yaml
+++ b/api/src/main/resources/db/changelog-master.yaml
@@ -40,3 +40,6 @@ databaseChangeLog:
   - include:
       file: changelog/20250305-115154-add-create-purchase-endpoint.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20250306-224010-add-fields-to-purchase.yaml
+      relativeToChangelogFile: true

--- a/api/src/main/resources/db/changelog/20250306-224010-add-fields-to-purchase.yaml
+++ b/api/src/main/resources/db/changelog/20250306-224010-add-fields-to-purchase.yaml
@@ -1,0 +1,78 @@
+databaseChangeLog:
+- changeSet:
+    id: 1741300857351-1
+    author: Yassine (generated)
+    changes:
+    - createTable:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: PurchaseDbEntity_id
+            type: UUID
+        - column:
+            name: images
+            type: VARCHAR(255)
+        tableName: PurchaseDbEntity_images
+- changeSet:
+    id: 1741300857351-2
+    author: Yassine (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: model
+            type: VARCHAR(255)
+        tableName: purchases
+- changeSet:
+    id: 1741300857351-3
+    author: Yassine (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: name
+            type: VARCHAR(255)
+        tableName: purchases
+- changeSet:
+    id: 1741300857351-4
+    author: Yassine (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: rating
+            type: INTEGER
+        tableName: purchases
+- changeSet:
+    id: 1741300857351-5
+    author: Yassine (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            constraints:
+              nullable: false
+            name: store
+            type: VARCHAR(255)
+        tableName: purchases
+- changeSet:
+    id: 1741300857351-6
+    author: Yassine (generated)
+    changes:
+    - addForeignKeyConstraint:
+        baseColumnNames: PurchaseDbEntity_id
+        baseTableName: PurchaseDbEntity_images
+        constraintName: FKlbh6sb5662qaloirqvdfek0gf
+        deferrable: false
+        initiallyDeferred: false
+        referencedColumnNames: id
+        referencedTableName: purchases
+        validate: true
+

--- a/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakePurchaseRepository.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/common/infra/adapters/fakes/FakePurchaseRepository.java
@@ -19,11 +19,16 @@ public class FakePurchaseRepository implements PurchaseRepositoryPort {
         UUID id = UUID.randomUUID();
 
         Purchase entity = new Purchase(
-                id,
-                purchase.userId(),
-                purchase.purchaseDate(),
-                purchase.brand(),
-                purchase.price()
+            id,
+            purchase.userId(),
+            purchase.name(),
+            purchase.purchaseDate(),
+            purchase.brand(),
+            purchase.model(),
+            purchase.store(),
+            purchase.images(),
+            purchase.price(),
+            purchase.rating()
         );
         purchasesTable.put(id, entity);
 
@@ -38,7 +43,14 @@ public class FakePurchaseRepository implements PurchaseRepositoryPort {
     @Override
     public Stream<Purchase> findByUserId(UUID userId) {
         return purchasesTable.values()
-                .stream()
-                .filter(purchase -> purchase.userId().equals(userId));
+            .stream()
+            .filter(purchase -> purchase.userId().equals(userId));
+    }
+
+    @Override
+    public Stream<Purchase> findCoworkersPurchases(UUID userId) {
+        return purchasesTable.values()
+            .stream()
+            .filter(purchase -> !purchase.userId().equals(userId));
     }
 }

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseEndpointIntegrationTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/api/endpoints/getcoworkerspurchase/GetCoworkersPurchaseEndpointIntegrationTests.java
@@ -1,0 +1,115 @@
+package com.nimbleways.springboilerplate.features.purchases.api.endpoints.getcoworkerspurchase;
+
+import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.suts.GetCoworkersPurchaseSut;
+import com.nimbleways.springboilerplate.testhelpers.BaseWebMvcIntegrationTests;
+import com.nimbleways.springboilerplate.testhelpers.helpers.UserSessionHelperSut;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.UUID;
+
+import static com.nimbleways.springboilerplate.testhelpers.fixtures.NewPurchaseFixture.aNewPurchase;
+import static com.nimbleways.springboilerplate.testhelpers.helpers.TokenHelpers.urlEncodeAccessToken;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = GetCoworkersPurchaseEndpoint.class)
+@Import(GetCoworkersPurchaseSut.class)
+class GetCoworkersPurchaseEndpointIntegrationTests extends BaseWebMvcIntegrationTests {
+    public static final String GET_COWORKERS_PURCHASE_ENDPOINT = "/purchases/getcoworkers";
+
+    @Autowired
+    private GetCoworkersPurchaseSut sut;
+
+    @Test
+    void returns_nonempty_purchases_when_get_purchases_succeed() throws Exception {
+        // GIVEN
+        UserSessionHelperSut.TestData testData1 = sut.sessionHelper().addUserAndSessionToRepository();
+        UserSessionHelperSut.TestData testData2 = sut.sessionHelper().addUserAndSessionToRepository();
+
+        Purchase purchase1 = sut.purchaseRepository().create(aNewPurchase().build(testData1.user().id()));
+        Purchase purchase2 = sut.purchaseRepository().create(aNewPurchase().build(testData2.user().id()));
+
+        // WHEN
+        ResultActions query1 = mockMvc
+            .perform(
+                get(GET_COWORKERS_PURCHASE_ENDPOINT)
+                    .cookie(new Cookie("accessToken", urlEncodeAccessToken(testData1.userTokens())))
+                    .contentType("application/json")
+                    .content(getRequestJson(testData1.user().id()))
+            );
+
+        ResultActions query2 = mockMvc
+            .perform(
+                get(GET_COWORKERS_PURCHASE_ENDPOINT)
+                    .cookie(new Cookie("accessToken", urlEncodeAccessToken(testData2.userTokens())))
+                    .contentType("application/json")
+                    .content(getRequestJson(testData2.user().id()))
+            );
+
+
+        // THEN
+        query1
+            .andExpect(status().isOk())
+            .andExpect(content().json(getResponseJson(purchase2)));
+
+        query2
+            .andExpect(status().isOk())
+            .andExpect(content().json(getResponseJson(purchase1)));
+    }
+
+
+    @Test
+    void returns_403_error_when_not_authenticated() throws Exception {
+        // WHEN
+        mockMvc
+            .perform(
+                get(GET_COWORKERS_PURCHASE_ENDPOINT)
+                    .contentType("application/json")
+                    .content(getRequestJson(UUID.randomUUID()))
+            )
+
+            // THEN
+            .andExpect(status().isForbidden());
+    }
+
+    private static String getRequestJson(UUID userId) {
+        return """
+            {
+                "userId": "%s"
+            }
+            """.formatted(userId);
+    }
+
+    private static String getResponseJson(Purchase purchase) {
+        String images = purchase.images().collect(image -> "\"" + image + "\"").makeString("[", ",", "]");
+        return """
+            [{
+                "id": "%s",
+                "purchaseDate": "%s",
+                "name": "%s",
+                "brand": "%s",
+                "model": "%s",
+                "store": "%s",
+                "images": %s,
+                "price": %s,
+                "rating": %s
+            }]
+            """.formatted(
+            purchase.id().toString(),
+            purchase.purchaseDate().toString(),
+            purchase.name(),
+            purchase.brand(),
+            purchase.model(),
+            purchase.store(),
+            images,
+            purchase.price().value(),
+            purchase.rating().value()
+        );
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/ports/PurchaseRepositoryPortContractTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/ports/PurchaseRepositoryPortContractTests.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static com.nimbleways.springboilerplate.testhelpers.fixtures.NewPurchaseFixture.aNewPurchase;
+
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,67 @@ public abstract class PurchaseRepositoryPortContractTests {
 
         // THEN
         assertEquals(List.of(entity), purchases);
+    }
+
+    @Test
+    @Transactional
+    void findCoworkersPurchases_inexistent_userid_yields_empty() {
+        // GIVEN
+        UUID userId = UUID.randomUUID();
+
+        // WHEN
+        List<Purchase> purchases = purchaseRepositoryPort.findCoworkersPurchases(userId).toList();
+
+        // THEN
+        assertEquals(0, purchases.size());
+    }
+
+    @Test
+    @Transactional
+    void findCoworkersPurchases_no_other_user_yields_empty() {
+        // GIVEN
+        User user = userRepositoryPort.create(aNewUser().build());
+
+        // WHEN
+        List<Purchase> purchases = purchaseRepositoryPort.findCoworkersPurchases(user.id()).toList();
+
+        // THEN
+        assertEquals(0, purchases.size());
+    }
+
+    @Test
+    @Transactional
+    void findCoworkersPurchases_no_purchase_yields_empty() {
+        // GIVEN
+        User user1 = userRepositoryPort.create(aNewUser().build());
+        User user2 = userRepositoryPort.create(aNewUser().build());
+
+        // WHEN
+        List<Purchase> purchases1 = purchaseRepositoryPort.findCoworkersPurchases(user1.id()).toList();
+        List<Purchase> purchases2 = purchaseRepositoryPort.findCoworkersPurchases(user2.id()).toList();
+
+        // THEN
+        assertEquals(0, purchases1.size());
+        assertEquals(0, purchases2.size());
+    }
+
+    @Test
+    @Transactional
+    void findCoworkersPurchases_with_purchases_yields_correct_result() {
+        // GIVEN
+        User user1 = userRepositoryPort.create(aNewUser().build());
+        User user2 = userRepositoryPort.create(aNewUser().build());
+
+        Purchase entity1 = purchaseRepositoryPort.create(aNewPurchase().build(user1.id()));
+        Purchase entity2 = purchaseRepositoryPort.create(aNewPurchase().build(user2.id()));
+
+        // WHEN
+        List<Purchase> purchases1 = purchaseRepositoryPort.findCoworkersPurchases(user1.id()).toList();
+        List<Purchase> purchases2 = purchaseRepositoryPort.findCoworkersPurchases(user2.id()).toList();
+
+        // THEN
+        assertEquals(List.of(entity2), purchases1);
+        assertEquals(List.of(entity1), purchases2);
     }
 
     @Test

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/CreatePurchaseUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/CreatePurchaseUseCaseUnitTests.java
@@ -1,6 +1,8 @@
 package com.nimbleways.springboilerplate.features.purchases.domain.usecases;
 
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
+import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
 import com.nimbleways.springboilerplate.features.purchases.domain.usecases.createpurchase.CreatePurchaseCommand;
 import com.nimbleways.springboilerplate.features.purchases.domain.usecases.suts.CreatePurchaseSut;
@@ -20,9 +22,14 @@ class CreatePurchaseUseCaseUnitTests {
         // GIVEN
         User user = sut.sessionHelper().addUserAndSessionToRepository().user();
         CreatePurchaseCommand command = new CreatePurchaseCommand(
-                user.id(),
-                "brand",
-                new Money(19)
+            user.id(),
+            "name",
+            "brand",
+            "model",
+            "store",
+            Immutable.list.of(""),
+            new Money(7.5),
+            new StarRating(3)
         );
 
         // WHEN

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/GetCoworkersPurchaseUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/GetCoworkersPurchaseUseCaseUnitTests.java
@@ -1,0 +1,37 @@
+package com.nimbleways.springboilerplate.features.purchases.domain.usecases;
+
+import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase.GetCoworkersPurchaseCommand;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.suts.GetCoworkersPurchaseSut;
+import com.nimbleways.springboilerplate.features.users.domain.entities.User;
+import com.nimbleways.springboilerplate.testhelpers.annotations.UnitTest;
+import com.nimbleways.springboilerplate.testhelpers.utils.Instance;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.nimbleways.springboilerplate.testhelpers.fixtures.NewPurchaseFixture.aNewPurchase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@UnitTest
+class GetCoworkersPurchaseUseCaseUnitTests {
+    private final GetCoworkersPurchaseSut sut = Instance.create(GetCoworkersPurchaseSut.class);
+
+    @Test
+    void returns_list_of_other_purchases_when_authenticated() {
+        // GIVEN
+        User user1 = sut.sessionHelper().addUserAndSessionToRepository().user();
+        User user2 = sut.sessionHelper().addUserAndSessionToRepository().user();
+
+        Purchase purchase1 = sut.purchaseRepository().create(aNewPurchase().build(user1.id()));
+        Purchase purchase2 = sut.purchaseRepository().create(aNewPurchase().build(user2.id()));
+
+        // WHEN
+        List<Purchase> result1 = sut.handle(new GetCoworkersPurchaseCommand(user1.id())).toList();
+        List<Purchase> result2 = sut.handle(new GetCoworkersPurchaseCommand(user2.id())).toList();
+
+        // THEN
+        assertEquals(List.of(purchase2), result1);
+        assertEquals(List.of(purchase1), result2);
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/GetPurchasesUseCaseUnitTests.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/GetPurchasesUseCaseUnitTests.java
@@ -17,7 +17,7 @@ class GetPurchasesUseCaseUnitTests {
     private final GetPurchasesSut sut = Instance.create(GetPurchasesSut.class);
 
     @Test
-    void returns_authenticated_user() {
+    void returns_list_of_purchases_when_authenticated() {
         // GIVEN
         User user = sut.sessionHelper().addUserAndSessionToRepository().user();
         Purchase purchase = sut.purchaseRepository().create(aNewPurchase().build(user.id()));

--- a/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/suts/GetCoworkersPurchaseSut.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/features/purchases/domain/usecases/suts/GetCoworkersPurchaseSut.java
@@ -1,0 +1,32 @@
+package com.nimbleways.springboilerplate.features.purchases.domain.usecases.suts;
+
+import com.nimbleways.springboilerplate.common.infra.adapters.fakes.FakePurchaseRepository;
+import com.nimbleways.springboilerplate.features.purchases.domain.entities.Purchase;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase.GetCoworkersPurchaseCommand;
+import com.nimbleways.springboilerplate.features.purchases.domain.usecases.getcoworkerspurchase.GetCoworkersPurchaseUseCase;
+import com.nimbleways.springboilerplate.testhelpers.helpers.UserSessionHelperSut;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Import;
+
+import java.util.stream.Stream;
+
+@Getter
+@Import({
+    GetCoworkersPurchaseUseCase.class,
+    FakePurchaseRepository.class,
+    UserSessionHelperSut.class
+})
+@RequiredArgsConstructor
+public class GetCoworkersPurchaseSut {
+    @Getter(AccessLevel.NONE)
+    private final GetCoworkersPurchaseUseCase useCase;
+
+    private final FakePurchaseRepository purchaseRepository;
+    private final UserSessionHelperSut sessionHelper;
+
+    public Stream<Purchase> handle(GetCoworkersPurchaseCommand command) {
+        return useCase.handle(command);
+    }
+}

--- a/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/NewPurchaseFixture.java
+++ b/api/src/test/java/com/nimbleways/springboilerplate/testhelpers/fixtures/NewPurchaseFixture.java
@@ -2,6 +2,8 @@ package com.nimbleways.springboilerplate.testhelpers.fixtures;
 
 import com.nimbleways.springboilerplate.common.domain.ports.TimeProviderPort;
 import com.nimbleways.springboilerplate.common.domain.valueobjects.Money;
+import com.nimbleways.springboilerplate.common.domain.valueobjects.StarRating;
+import com.nimbleways.springboilerplate.common.utils.collections.Immutable;
 import com.nimbleways.springboilerplate.features.purchases.domain.valueobjects.NewPurchase;
 import com.nimbleways.springboilerplate.testhelpers.configurations.TimeTestConfiguration;
 
@@ -11,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.With;
 import org.jetbrains.annotations.NotNull;
+import org.eclipse.collections.api.list.ImmutableList;
 
 public class NewPurchaseFixture {
 
@@ -23,17 +26,28 @@ public class NewPurchaseFixture {
     @With
     @AllArgsConstructor
     public static final class Builder {
+        private String name = "nameX";
         private String brand = "brandX";
+        private String model = "modelX";
+        private String store = "storeX";
         private Money price = new Money(100.0);
+        private StarRating rating = new StarRating(5);
+        private ImmutableList<String> images = Immutable.list.of("image1", "image2");
         private TimeProviderPort timeProvider = TimeTestConfiguration.fixedTimeProvider();
 
         @NotNull
         public NewPurchase build(UUID userId) {
             return new NewPurchase(
-                    userId,
-                    timeProvider.instant(),
-                    brand,
-                    price);
+                userId,
+                name,
+                timeProvider.instant(),
+                brand,
+                model,
+                store,
+                images,
+                price,
+                rating
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- added fields to the purchase entity.
- added endpoints and use case for fetching other purchases of users.
- add integration and unit tests.
- added migration file for the given changes.

## Trello Card
- Closes [TC#31](https://trello.com/c/1y1MjtjK/31-4-etq-theodoer-connect%C3%A9-sur-la-tab-coworkers-je-peux-voir-la-liste-de-tous-les-achats-de-mes-collaborateurs)

## Breaking Changes
❗The `purchase` entity now has more fields, as a result the requests and responses have also changed to reflect to the new fields.